### PR TITLE
standards-cruds-fixes to master

### DIFF
--- a/app/Http/Controllers/Admin/StandardCategoryCrudController.php
+++ b/app/Http/Controllers/Admin/StandardCategoryCrudController.php
@@ -93,7 +93,7 @@ class StandardCategoryCrudController extends CrudController
             'name'  => 'Standardtable',
             'label' => 'Standards',
             'type'  => 'repeatable',
-            'entity' => 'standards',
+            //'entity' => 'standards',
             'fields' => [
                 [
                     'name'    => 'standard_id',

--- a/app/Http/Controllers/Admin/StandardsScaleCategoryCrudController.php
+++ b/app/Http/Controllers/Admin/StandardsScaleCategoryCrudController.php
@@ -110,7 +110,7 @@ class StandardsScaleCategoryCrudController extends CrudController
             'name'  => 'Scaletable',
             'label' => 'Scales',
             'type'  => 'repeatable',
-            'entity' => 'ministryStandardScales',
+            //'entity' => 'ministryStandardScales',
             
             'fields' => [
                 [


### PR DESCRIPTION
commented out 'entity' declaration, as it was causing errors with the edit function